### PR TITLE
fix: Files given through --file option should run before the other spec files

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -29,10 +29,11 @@ const { isDebugEnabled, lineBreak } = require('./util');
       spec,
     };
 
-    const collectedFiles = collectFiles(fileCollectParams);
-    debug('collected files: %O', collectedFiles);
+    const { collectedSpecFiles, filesGivenThroughFileOption } = collectFiles(
+      fileCollectParams
+    );
 
-    if (!collectedFiles.length) {
+    if (collectedSpecFiles.length === 0 && filesGivenThroughFileOption.length === 0) {
       console.log(
         yellow('Based on your Mocha configuration, no spec files were matched!')
       );
@@ -40,12 +41,21 @@ const { isDebugEnabled, lineBreak } = require('./util');
       process.exit();
     }
 
-    const filteredFiles = await promptFilter(collectedFiles);
+    // note: filter list won't display files that are given through --file option
+    const filteredFiles = await promptFilter(collectedSpecFiles);
 
     if (isDebugEnabled()) lineBreak(2);
     debug('filtered files: %O', filteredFiles);
 
-    await switchToTestRunnerMode(filteredFiles, collectedFiles, options);
+    // add files given through --file to be ran first
+    const filesToBeExecuted = filesGivenThroughFileOption.concat(filteredFiles);
+    debug('files to be executed: %O', filesToBeExecuted);
+
+    await switchToTestRunnerMode(
+      filesToBeExecuted,
+      { collectedSpecFiles, filesGivenThroughFileOption },
+      options
+    );
   } catch (error) {
     console.error(error);
     process.exit(1);

--- a/lib/cli/print.js
+++ b/lib/cli/print.js
@@ -29,7 +29,7 @@ function printTestRunnerUsage(stdout = process.stdout) {
   stdout.write(
     ` ${dim(`${arrow} Press`)} ${white().bold('Esc')} ${dim(
       'to quit test runner mode.'
-    )}\n`
+    )}\n\n`
   );
 }
 

--- a/lib/cli/test-runner.js
+++ b/lib/cli/test-runner.js
@@ -8,7 +8,7 @@ const promptFilter = require('./filter');
 
 let isInFilterMode = false;
 let boundedKeypressHandler = null;
-let recentlyFilteredFiles = [];
+let filesToBeExecuted = [];
 
 function getInitializedReadline() {
   if (process.stdin.isTTY) process.stdin.setRawMode(true);
@@ -29,34 +29,36 @@ function closeReadline(rl) {
   rl.close();
 }
 
-async function handleKeypress({ rl, reRunner, collectedFiles }, _, key) {
+async function handleKeypress({ rl, reRunner, files }, _, key) {
   // Ctrl + c || Esc
   if ((key.ctrl && key.name === 'c') || key.name === 'escape') {
-    showCursor();
     process.exit();
   }
 
   if (key.name === 'f') {
     debug('switching to filter mode');
+    closeReadline(rl);
     isInFilterMode = true;
 
     if (reRunner.runner) {
       debug('aborting test execution');
       reRunner.runner.abort();
     }
-    closeReadline(rl);
 
-    recentlyFilteredFiles = await promptFilter(collectedFiles);
+    const newFilteredFiles = await promptFilter(files.collectedSpecFiles);
 
     if (isDebugEnabled()) lineBreak(2);
-    debug('new filtered files: %O', recentlyFilteredFiles);
+    debug('new filtered files: %O', newFilteredFiles);
+
+    filesToBeExecuted = files.filesGivenThroughFileOption.concat(newFilteredFiles);
+    debug('new files to be executed: %O', filesToBeExecuted);
 
     // switch back to test runner
     isInFilterMode = false;
 
     boundedKeypressHandler = handleKeypress.bind(null, {
       rl: getInitializedReadline(),
-      collectedFiles,
+      files,
       reRunner,
     });
     process.stdin.on('keypress', boundedKeypressHandler);
@@ -65,29 +67,38 @@ async function handleKeypress({ rl, reRunner, collectedFiles }, _, key) {
     hideCursor();
 
     debug('Scheduling a run');
-    reRunner.scheduleRun(recentlyFilteredFiles);
+    reRunner.scheduleRun(filesToBeExecuted);
   }
 }
 
-async function switchToTestRunnerMode(filteredFiles, collectedFiles, mochaOptions) {
-  recentlyFilteredFiles = filteredFiles;
+async function switchToTestRunnerMode(_filesToBeExecuted, files, mochaOptions) {
+  filesToBeExecuted = _filesToBeExecuted;
   const rl = getInitializedReadline();
 
   try {
     const { watcher, reRunner } = await run(mochaOptions);
 
     watcher.on('ready', () => {
-      reRunner.run(recentlyFilteredFiles);
+      reRunner.run(filesToBeExecuted);
     });
 
     watcher.on('all', () => {
       if (isInFilterMode) return;
 
-      reRunner.scheduleRun(recentlyFilteredFiles);
+      reRunner.scheduleRun(filesToBeExecuted);
+    });
+
+    process.on('exit', () => {
+      showCursor();
+    });
+
+    process.on('SIGINT', () => {
+      showCursor();
+      process.exit(128 + 2);
     });
 
     // why not inline callback? because we need the handler ref to remove later.
-    boundedKeypressHandler = handleKeypress.bind(null, { rl, collectedFiles, reRunner });
+    boundedKeypressHandler = handleKeypress.bind(null, { rl, files, reRunner });
     process.stdin.on('keypress', boundedKeypressHandler);
 
     printTestRunnerUsage();

--- a/lib/mocha/collect-files.js
+++ b/lib/mocha/collect-files.js
@@ -49,12 +49,14 @@ module.exports = function collectFiles({
 
   if (sort) files.sort();
 
-  // add files given through --file to be ran first
-  files = fileArgs.concat(files);
-  debug('files (in order): ', files);
+  debug('collected spec files (in order): ', files);
+  debug('files given through --file option: ', fileArgs);
 
   if (!files.length) debug('no test files found');
   if (unmatched.length) debug('unmatched files: ', unmatched);
 
-  return files;
+  return {
+    collectedSpecFiles: files,
+    filesGivenThroughFileOption: fileArgs,
+  };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,7 +169,8 @@
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.1",
@@ -562,6 +563,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mocha-watch-typeahead",
   "version": "0.0.1",
-  "description": "Filter tests by file name",
+  "description": "An attempt to add interactive watch mode support for the mocha test framework.",
   "bin": {
     "mocha-watch": "./bin/mocha-watch.js"
   },
@@ -9,7 +9,7 @@
     "node": ">= 10.12.0"
   },
   "files": [
-    "./bin",
+    "bin",
     "lib"
   ],
   "scripts": {
@@ -33,7 +33,11 @@
     "type": "git",
     "url": "git+https://github.com/m-sureshraj/mocha-watch-typeahead.git"
   },
-  "keywords": [],
+  "keywords": [
+    "mocha",
+    "cli",
+    "typeahead"
+  ],
   "author": "Sureshraj <m.s.suresh100@gmail.com>",
   "license": "ISC",
   "bugs": {
@@ -44,7 +48,6 @@
     "ansi-escapes": "^4.3.1",
     "camelcase": "^6.0.0",
     "chokidar": "3.4.2",
-    "enquirer": "^2.3.6",
     "is-glob": "^4.0.1",
     "kleur": "^4.1.1",
     "micromatch": "^4.0.2",


### PR DESCRIPTION
* Updated the `collectFiles` function to return collected spec files, files given through --file
  option separately
* Removed unused dependency. `enquirer`